### PR TITLE
Capability to install untwisted both as python2 and python3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@ untwisted
 =========
 
 A library for asynchronous programming in python.
+
+This version installs both python2 and python3 versions of untwisted.
+
+To install the python3 version, run
+
+```
+# python3 setup.py install
+```

--- a/setup.py
+++ b/setup.py
@@ -8,19 +8,11 @@ try:
 except ImportError:
    from distutils.command.build_py import build_py
 
-setup(name="vy",
+setup(name="untwisted",
       version="0.1",
-      packages=["vyapp", 
-                "vyapp.plugins",
-                "vyapp.plugins.syntax",
-                "vyapp.plugins.omen",             
-                "vyapp.plugins.syntax.themes",
-		"vyapp.plugins.jdb",
-		"vyapp.plugins.pdb"],
-      #package_dir={'vyapp':'vyapp'},
-      scripts=['vy'],
-      package_data={'vyapp': ['vyrc', '/vyapp/vyrc']},
+      packages=["untwisted", 
+                "untwisted.utils"],
       author="Iury O. G. Figueiredo",
-      author_email="ioliveira@id.uff.br",
+      author_email="ioliveira@id.uff.br")
       cmdclass = {'build_py': build_py}
 )

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,26 @@
 #! /usr/bin/env python
 
 from distutils.core import setup
-setup(name="untwisted",
+
+try:
+   from distutils.command.build_py import build_py_2to3 \
+        as build_py
+except ImportError:
+   from distutils.command.build_py import build_py
+
+setup(name="vy",
       version="0.1",
-      packages=["untwisted", 
-                "untwisted.utils"],
+      packages=["vyapp", 
+                "vyapp.plugins",
+                "vyapp.plugins.syntax",
+                "vyapp.plugins.omen",             
+                "vyapp.plugins.syntax.themes",
+		"vyapp.plugins.jdb",
+		"vyapp.plugins.pdb"],
+      #package_dir={'vyapp':'vyapp'},
+      scripts=['vy'],
+      package_data={'vyapp': ['vyrc', '/vyapp/vyrc']},
       author="Iury O. G. Figueiredo",
-      author_email="ioliveira@id.uff.br")
-
-
+      author_email="ioliveira@id.uff.br",
+      cmdclass = {'build_py': build_py}
+)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(name="untwisted",
       packages=["untwisted", 
                 "untwisted.utils"],
       author="Iury O. G. Figueiredo",
-      author_email="ioliveira@id.uff.br")
+      author_email="ioliveira@id.uff.br",
       cmdclass = {'build_py': build_py}
 )


### PR DESCRIPTION
This will install untwisted in the python version that setup.py is called with. i.e:

```
# python setup.py install
```

installs the python2 version on most systems,

```
# python3 setup.py install
```

installs the python3 version.
